### PR TITLE
V14 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,7 @@ Whether to group unlinked tokens in the combat tracker.
 
 ## Damage Type Appearance
 
+> [!NOTE]
+> Only applies if running Dice So Nice version 5.x or earlier. DSN version 6.0 added the feature itself.
+
 Changes the appearance of damage dice based on the damage type (e.g. fire damage is red).

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14"
   },
   "relationships": {
     "systems": [
@@ -12,7 +12,7 @@
         "id": "dnd5e",
         "compatibility": {
           "minimum": "5.0.0",
-          "verified": "5.1.10"
+          "verified": "5.3.3"
         }
       }
     ]

--- a/src/kaelad-custom.js
+++ b/src/kaelad-custom.js
@@ -115,8 +115,13 @@ Hooks.once("init", () => {
         default: "default"
       },
       initClass: groupInitiative
-    },
-    damageTypeAppearance: {
+    }
+  };
+
+  // only use if using Dice So Nice pre-6.0
+  const dsn = game.modules.get("dice-so-nice");
+  if (dsn?.active && !foundry.utils.isNewerVersion(dsn?.version, "5.9.99"))
+    settings.damageTypeAppearance = {
       config: {
         name: "Damage Type Appearance",
         hint: "Changes the appearance of damage dice based on the damage type (e.g. fire damage is red).",
@@ -127,8 +132,7 @@ Hooks.once("init", () => {
         default: false,
       },
       initClass: damageTypeAppearance
-    }
-  };
+    };
 
   for (const [key, setting] of Object.entries(settings)) {
     game.settings.register("kaelad-custom-5e", key, setting.config);

--- a/src/modules/optional-bonuses.js
+++ b/src/modules/optional-bonuses.js
@@ -4,11 +4,16 @@
 
 const { BooleanField } = foundry.data.fields;
 
+let useAdv;
+
 export function init() {
-  // monkeypatch to make criticals support dice pools (e.g. {2d6, 2d6}kh)
-  dnd5e.dice.DamageRoll.prototype.configureDamage = funNewConfigureDamage;
-  // TODO remove when system version updated to 5.2.0
-  dnd5e.documents.ChatMessage5e.prototype._simplifyDamageRoll = newSimplifyDamageRoll;
+  // only monkeypatch if pre-5.3 to make criticals support dice pools (e.g. {2d6, 2d6}kh)
+  useAdv = foundry.utils.isNewerVersion(game.system.version, "5.2.99");
+  if (!useAdv)
+    dnd5e.dice.DamageRoll.prototype.configureDamage = funNewConfigureDamage;
+  // only monkeypatch if pre-5.2
+  if (!foundry.utils.isNewerVersion(game.system.version, "5.1.99"))
+    dnd5e.documents.ChatMessage5e.prototype._simplifyDamageRoll = newSimplifyDamageRoll;
 
   // look for automatic bonuses earlier, before the buildDamageRollConfig hook
   Hooks.on("dnd5e.preRollDamageV2", (config, dialog, message) => {
@@ -47,7 +52,8 @@ export function init() {
     if (dialog.config.autoBonuses.greatWeaponFighting) addDieModifier(rollConfig, "min3");
     if (opts.sneakAttack) rollConfig.parts.push("@scale.rogue.sneak-attack");
     if (opts.dreadfulStrikes) rollConfig.parts.push("@scale.fey.dreadful-strike[psychic]");
-    if (opts.savageAttacker) rollConfig.parts[0] = `{${rollConfig.parts[0]}, ${rollConfig.parts[0]}}kh`;
+    if (opts.savageAttacker && useAdv) rollConfig.parts[0] = `${rollConfig.parts[0]}adv`;
+    else if (opts.savageAttacker) rollConfig.parts[0] = `{${rollConfig.parts[0]}, ${rollConfig.parts[0]}}kh`;
     if (opts.greatWeaponMaster) rollConfig.parts.push("@prof");
     if (opts.blessedStrikesRadiant) rollConfig.parts.push("@scale.cleric.divine-strike[radiant]");
     if (opts.blessedStrikesNecrotic) rollConfig.parts.push("@scale.cleric.divine-strike[necrotic]");


### PR DESCRIPTION
- Use the new `adv` die modifier the system added in version 5.3.0
- Only use the Damage Type Appearance when using Dice So Nice version 5.x or earlier since version 6.0 added the feature